### PR TITLE
Add Travis CI script for Linux testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: csharp
+sudo: false   # use the new container-based Travis infrastructure
+install:
+  - nuget restore UriTemplates.sln
+script:
+  - xbuild /p:Configuration=Release /t:Compile build/Build.proj


### PR DESCRIPTION
I'm one of the contributors of the [C# support for Travis CI](http://blog.travis-ci.com/2014-12-10-community-driven-language-support-comes-to-travis-ci/) and thought you might find this useful for Linux testing via Mono.

I only execute the "Compile" msbuild target because the .nuspec contains backslashes and this would make nuget pack fail on Linux.

Example: https://travis-ci.org/akoeplinger/Tavis.UriTemplates/builds/46235467