### PR TITLE
Make parameter names case sensitive/insensitive

### DIFF
--- a/src/UriTemplates/UriTemplate.cs
+++ b/src/UriTemplates/UriTemplate.cs
@@ -28,7 +28,7 @@ namespace Tavis.UriTemplates
                                         };
 
             private readonly string _template;
-            private readonly Dictionary<string, object> _Parameters = new Dictionary<string, object>();
+            private readonly Dictionary<string, object> _Parameters;
             private enum States { CopyingLiterals, ParsingExpression }
             private bool _ErrorDetected = false;
             private Result _Result;
@@ -36,10 +36,13 @@ namespace Tavis.UriTemplates
 
             private bool _resolvePartially;
 
-            public UriTemplate(string template, bool resolvePartially = false )
+            public UriTemplate(string template, bool resolvePartially = false, bool caseInsensitiveParameterNames = false)
             {
                 _resolvePartially = resolvePartially;
                 _template = template;
+                _Parameters = caseInsensitiveParameterNames
+                    ? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                    : new Dictionary<string, object>();
             }
 
             public override string ToString()


### PR DESCRIPTION
We found that the template resolution was depending on the parameters
being added to mach the same case as the template casing. Now you
can specify whether you want case sensitivity on your `UriTemplate`
instance or not.