### PR TITLE
Added a unit test that shows that currently GetParameters' result dep…

### DIFF
--- a/src/UriTemplateTests/ParameterMatchingTests.cs
+++ b/src/UriTemplateTests/ParameterMatchingTests.cs
@@ -87,6 +87,7 @@ namespace UriTemplateTests
             Assert.Equal("45", parameters["blur"]);
 
         }
+
         [Fact]
         public void GetParametersFromMultipleQueryStringWithTwoParamValues()
         {
@@ -96,6 +97,24 @@ namespace UriTemplateTests
 
             var parameters = template.GetParameters(uri);
 
+            Assert.Equal(4, parameters.Count);
+            Assert.Equal("foo", parameters["p1"]);
+            Assert.Equal("bar", parameters["p2"]);
+            Assert.Equal("45", parameters["blur"]);
+            Assert.Equal("23", parameters["blob"]);
+
+        }
+
+        [Fact]
+        public void GetParametersFromMultipleQueryStringWithTwoParamValuesDoesNotDependOnOrderOfQueryParameters()
+        {
+            var uri = new Uri("http://example.com/foo/bar?blob=23&blur=45");
+
+            var template = new UriTemplate("http://example.com/{+p1}/{p2*}{?blur,blob}");
+
+            var parameters = template.GetParameters(uri);
+
+            Assert.NotNull(parameters);
             Assert.Equal(4, parameters.Count);
             Assert.Equal("foo", parameters["p1"]);
             Assert.Equal("bar", parameters["p2"]);


### PR DESCRIPTION
Hi Darrel!

You may remember me, I was the guy that "pushed" you to release UriTemplates! :)
I'm glad you did, because it is useful.

Today I found a bug: the "GetParameters()" method result is dependent on the order of template parameters. F. e. given a uri template "http://test.tld{? foo, bar}", then "http://test.tld?foo=1&bar=2" works, but not "http://test.tld?bar=2&foo=1".
I have added a unit test that shows the behavior (see the diff).

By the way: i feel that "GetParameters()" should return an empty dictionary instead of null when it does not find a match, at least that is what I would expect it to return.

Lots of thanks for the code and kind regards,
K.