### PR TITLE
Added method to get query string parameters insignificant of order

### DIFF
--- a/src/UriTemplateTests/ParameterMatchingTests.cs
+++ b/src/UriTemplateTests/ParameterMatchingTests.cs
@@ -87,6 +87,7 @@ namespace UriTemplateTests
             Assert.Equal("45", parameters["blur"]);
 
         }
+
         [Fact]
         public void GetParametersFromMultipleQueryStringWithTwoParamValues()
         {
@@ -96,6 +97,24 @@ namespace UriTemplateTests
 
             var parameters = template.GetParameters(uri);
 
+            Assert.Equal(4, parameters.Count);
+            Assert.Equal("foo", parameters["p1"]);
+            Assert.Equal("bar", parameters["p2"]);
+            Assert.Equal("45", parameters["blur"]);
+            Assert.Equal("23", parameters["blob"]);
+
+        }
+
+        [Fact]
+        public void GetParametersFromMultipleQueryStringWithTwoParamValuesDoesNotDependOnOrderOfQueryParameters()
+        {
+            var uri = new Uri("http://example.com/foo/bar?blob=23&blur=45");
+
+            var template = new UriTemplate("http://example.com/{+p1}/{p2*}{?blur,blob}");
+
+            var parameters = template.GetParameters(uri);
+
+            Assert.NotNull(parameters);
             Assert.Equal(4, parameters.Count);
             Assert.Equal("foo", parameters["p1"]);
             Assert.Equal("bar", parameters["p2"]);

--- a/src/UriTemplateTests/ParameterMatchingTests.cs
+++ b/src/UriTemplateTests/ParameterMatchingTests.cs
@@ -26,6 +26,8 @@ namespace UriTemplateTests
             Assert.True(match);
         }
 
+        #region GetParameters()
+
         [Fact]
         public void GetParameters()
         {
@@ -38,7 +40,7 @@ namespace UriTemplateTests
 
             var match = regex.Match(uri.AbsoluteUri);
 
-            Assert.Equal("foo",match.Groups["p1"].Value);
+            Assert.Equal("foo", match.Groups["p1"].Value);
             Assert.Equal("bar", match.Groups["p2"].Value);
         }
 
@@ -106,24 +108,6 @@ namespace UriTemplateTests
         }
 
         [Fact]
-        public void GetParametersFromMultipleQueryStringWithTwoParamValuesDoesNotDependOnOrderOfQueryParameters()
-        {
-            var uri = new Uri("http://example.com/foo/bar?blob=23&blur=45");
-
-            var template = new UriTemplate("http://example.com/{+p1}/{p2*}{?blur,blob}");
-
-            var parameters = template.GetParameters(uri);
-
-            Assert.NotNull(parameters);
-            Assert.Equal(4, parameters.Count);
-            Assert.Equal("foo", parameters["p1"]);
-            Assert.Equal("bar", parameters["p2"]);
-            Assert.Equal("45", parameters["blur"]);
-            Assert.Equal("23", parameters["blob"]);
-
-        }
-
-        [Fact]
         public void GetParametersFromMultipleQueryStringWithOptionalAndMandatoryParameters()
         {
             var uri = new Uri("http://example.com/foo/bar?blur=45&blob=23");
@@ -154,6 +138,113 @@ namespace UriTemplateTests
 
         }
 
+        [Fact]
+        public void GetParametersRespectsOrderOfQueryParameters()
+        {
+            var uri = new Uri("http://example.com/foo/bar?blob=23&blur=45");
+
+            var template = new UriTemplate("http://example.com/{+p1}/{p2*}{?blur,blob}");
+
+            var parameters = template.GetParameters(uri);
+
+            Assert.Null(parameters);
+        }
+
+        [Fact]
+        public void GetParametersReturnsNullWhenTheresNoMatch()
+        {
+            var uri = new Uri("http://example.com/foo/bar?one=23&two=45");
+
+            var template = new UriTemplate("http://example.com/foo/bar{?blur,blob}");
+
+            var parameters = template.GetParameters(uri);
+
+            Assert.Null(parameters);
+        }
+
+        #endregion 
+
+        #region GetParametersNonStrict()
+
+        [Fact]
+        public void GetParametersNonStrict()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParameters();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictWithOperators()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersWithOperators();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictFromQueryString()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersFromQueryString();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictFromMultipleQueryString()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersFromMultipleQueryString();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictFromMultipleQueryStringWithTwoParamValues()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersFromMultipleQueryStringWithTwoParamValues();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictFromMultipleQueryStringWithOptionalAndMandatoryParameters()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersFromMultipleQueryStringWithOptionalAndMandatoryParameters();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictFromMultipleQueryStringWithOptionalParameters()
+        {
+            // Make sure GetParametersNonStrict() behaves just like GetParameters() in this case
+            GetParametersFromMultipleQueryStringWithOptionalParameters();
+        }
+
+        [Fact]
+        public void GetParametersNonStrictIgnoresOrderOfQueryParameters()
+        {
+            var uri = new Uri("http://example.com/foo/bar?blob=23&blur=45&irrelevant=true");
+
+            var template = new UriTemplate("http://example.com/{+p1}/{p2*}{?blur,blob}");
+
+            var parameters = template.GetParametersNonStrict(uri);
+
+            Assert.Equal(4, parameters.Count);
+            Assert.Equal("foo", parameters["p1"]);
+            Assert.Equal("bar", parameters["p2"]);
+            Assert.Equal("23", parameters["blob"]);
+            Assert.Equal("45", parameters["blur"]);
+        }
+
+        [Fact]
+        public void GetParametersNonStrictReturnsEmptyDictionaryWhenTheresNoMatch()
+        {
+            var uri = new Uri("http://example.com/foo/bar?one=23&two=45");
+
+            var template = new UriTemplate("http://example.com/foo/bar{?blur,blob}");
+
+            var parameters = template.GetParametersNonStrict(uri);
+
+            Assert.NotNull(parameters);
+            Assert.Equal(0, parameters.Count);
+        }
+
+        #endregion 
 
         [Fact]
         public void TestGlimpseUrl()
@@ -181,8 +272,6 @@ namespace UriTemplateTests
             Assert.Equal("123", parameters["hash"]);
 
         }
-
-        
 
         [Fact]
         public void TestExactParameterCount()

--- a/src/UriTemplates/UriTemplate.cs
+++ b/src/UriTemplates/UriTemplate.cs
@@ -13,450 +13,481 @@ namespace Tavis.UriTemplates
     using System.Text;
 
 
-        public class UriTemplate
-        {
+    public class UriTemplate
+    {
 
 
-            private static Dictionary<char, OperatorInfo> _Operators = new Dictionary<char, OperatorInfo>() {
-                                        {'\0', new OperatorInfo {Default = true, First = "", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = false}},
-                                        {'+', new OperatorInfo {Default = false, First = "", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = true}},
-                                        {'.', new OperatorInfo {Default = false, First = ".", Seperator = '.', Named = false, IfEmpty = "",AllowReserved = false}},
-                                        {'/', new OperatorInfo {Default = false, First = "/", Seperator = '/', Named = false, IfEmpty = "",AllowReserved = false}},
-                                        {';', new OperatorInfo {Default = false, First = ";", Seperator = ';', Named = true, IfEmpty = "",AllowReserved = false}},
-                                        {'?', new OperatorInfo {Default = false, First = "?", Seperator = '&', Named = true, IfEmpty = "=",AllowReserved = false}},
-                                        {'&', new OperatorInfo {Default = false, First = "&", Seperator = '&', Named = true, IfEmpty = "=",AllowReserved = false}},
-                                        {'#', new OperatorInfo {Default = false, First = "#", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = true}}
-                                        };
+        private static Dictionary<char, OperatorInfo> _Operators = new Dictionary<char, OperatorInfo>() {
+                                    {'\0', new OperatorInfo {Default = true, First = "", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = false}},
+                                    {'+', new OperatorInfo {Default = false, First = "", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = true}},
+                                    {'.', new OperatorInfo {Default = false, First = ".", Seperator = '.', Named = false, IfEmpty = "",AllowReserved = false}},
+                                    {'/', new OperatorInfo {Default = false, First = "/", Seperator = '/', Named = false, IfEmpty = "",AllowReserved = false}},
+                                    {';', new OperatorInfo {Default = false, First = ";", Seperator = ';', Named = true, IfEmpty = "",AllowReserved = false}},
+                                    {'?', new OperatorInfo {Default = false, First = "?", Seperator = '&', Named = true, IfEmpty = "=",AllowReserved = false}},
+                                    {'&', new OperatorInfo {Default = false, First = "&", Seperator = '&', Named = true, IfEmpty = "=",AllowReserved = false}},
+                                    {'#', new OperatorInfo {Default = false, First = "#", Seperator = ',', Named = false, IfEmpty = "",AllowReserved = true}}
+                                    };
 
-            private readonly string _template;
-            private readonly Dictionary<string, object> _Parameters;
-            private enum States { CopyingLiterals, ParsingExpression }
+        private readonly string _template;
+        private readonly Dictionary<string, object> _Parameters;
+        private enum States { CopyingLiterals, ParsingExpression }
             
 
-            private readonly bool _resolvePartially;
+        private readonly bool _resolvePartially;
 
-            public UriTemplate(string template, bool resolvePartially = false, bool caseInsensitiveParameterNames = false)
-            {
-                _resolvePartially = resolvePartially;
-                _template = template;
-                _Parameters = caseInsensitiveParameterNames
-                    ? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
-                    : new Dictionary<string, object>();
-            }
+        public UriTemplate(string template, bool resolvePartially = false, bool caseInsensitiveParameterNames = false)
+        {
+            _resolvePartially = resolvePartially;
+            _template = template;
+            _Parameters = caseInsensitiveParameterNames
+                ? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, object>();
+        }
 
-            public override string ToString()
-            {
-                return _template;
-            }
+        public override string ToString()
+        {
+            return _template;
+        }
 
-            public void SetParameter(string name, object value)
-            {
-                _Parameters[name] = value;
-            }
+        public void SetParameter(string name, object value)
+        {
+            _Parameters[name] = value;
+        }
 
-            public void ClearParameter(string name)
-            {
-                _Parameters.Remove(name);
-            }
+        public void ClearParameter(string name)
+        {
+            _Parameters.Remove(name);
+        }
 
-            public void SetParameter(string name, string value)
-            {
-                _Parameters[name] = value;
-            }
+        public void SetParameter(string name, string value)
+        {
+            _Parameters[name] = value;
+        }
 
-            public void SetParameter(string name, IEnumerable<string> value)
-            {
-                _Parameters[name] = value;
-            }
+        public void SetParameter(string name, IEnumerable<string> value)
+        {
+            _Parameters[name] = value;
+        }
 
-            public void SetParameter(string name, IDictionary<string, string> value)
-            {
-                _Parameters[name] = value;
-            }
+        public void SetParameter(string name, IDictionary<string, string> value)
+        {
+            _Parameters[name] = value;
+        }
 
-            public IEnumerable<string> GetParameterNames()
-            {
-                Result result = ResolveResult();
-                return result.ParameterNames;
-            }
+        public IEnumerable<string> GetParameterNames()
+        {
+            Result result = ResolveResult();
+            return result.ParameterNames;
+        }
 
-            public string Resolve()
-            {
-                var result = ResolveResult();
-                return result.ToString();
-            }
+        public string Resolve()
+        {
+            var result = ResolveResult();
+            return result.ToString();
+        }
 
-            private Result ResolveResult()
+        private Result ResolveResult()
+        {
+            var currentState = States.CopyingLiterals;
+            var result = new Result();
+            StringBuilder currentExpression = null;
+            foreach (var character in _template.ToCharArray())
             {
-                var currentState = States.CopyingLiterals;
-                var result = new Result();
-                StringBuilder currentExpression = null;
-                foreach (var character in _template.ToCharArray())
+                switch (currentState)
                 {
-                    switch (currentState)
-                    {
-                        case States.CopyingLiterals:
-                            if (character == '{')
-                            {
-                                currentState = States.ParsingExpression;
-                                currentExpression = new StringBuilder();
-                            }
-                            else if (character == '}')
-                            {
-                                throw new ArgumentException("Malformed template, unexpected } : " + result.ToString());
-                            }
-                            else
-                            {
-                                result.Append(character);
-                            }
-                            break;
-                        case States.ParsingExpression:
-                            if (character == '}')
-                            {
-                                ProcessExpression(currentExpression, result);
-
-                                currentState = States.CopyingLiterals;
-                            }
-                            else
-                            {
-                                currentExpression.Append(character);
-                            }
-
-                            break;
-                    }
-                }
-                if (currentState == States.ParsingExpression)
-                {
-                    result.Append("{");
-                    result.Append(currentExpression.ToString());
-
-                    throw new ArgumentException("Malformed template, missing } : " + result.ToString());
-                }
-
-                if (result.ErrorDetected)
-                {
-                    throw new ArgumentException("Malformed template : " + result.ToString());
-                }
-                return result;
-            }
-
-            private void ProcessExpression(StringBuilder currentExpression, Result result)
-            {
-
-                if (currentExpression.Length == 0)
-                {
-                    result.ErrorDetected = true;
-                    result.Append("{}");
-                    return;
-                }
-
-                OperatorInfo op = GetOperator(currentExpression[0]);
-
-                var firstChar = op.Default ? 0 : 1;
-                bool multivariableExpression = false;
-
-                var varSpec = new VarSpec(op);
-                for (int i = firstChar; i < currentExpression.Length; i++)
-                {
-                    char currentChar = currentExpression[i];
-                    switch (currentChar)
-                    {
-                        case '*':
-                            varSpec.Explode = true;
-                            break;
-
-                        case ':':  // Parse Prefix Modifier
-                            var prefixText = new StringBuilder();
-                            currentChar = currentExpression[++i];
-                            while (currentChar >= '0' && currentChar <= '9' && i < currentExpression.Length)
-                            {
-                                prefixText.Append(currentChar);
-                                i++;
-                                if (i < currentExpression.Length) currentChar = currentExpression[i];
-                            }
-                            varSpec.PrefixLength = int.Parse(prefixText.ToString());
-                            i--;
-                            break;
-
-                        case ',':
-                            multivariableExpression = true;
-                            var success = ProcessVariable(varSpec, result, multivariableExpression);
-                            bool isFirst = varSpec.First;
-                            // Reset for new variable
-                            varSpec = new VarSpec(op);
-                            if (success || !isFirst || _resolvePartially) varSpec.First = false;
-                            if (!success && _resolvePartially) {result.Append(",") ; }
-                            break; 
-                        
-
-                        default:
-                            if (IsVarNameChar(currentChar))
-                            {
-                                varSpec.VarName.Append(currentChar);
-                            }
-                            else
-                            {
-                                result.ErrorDetected = true;
-                            }
-                            break;
-                    }
-                }
-
-                ProcessVariable(varSpec, result, multivariableExpression);
-                if (multivariableExpression && _resolvePartially) result.Append("}");
-            }
-
-            private bool ProcessVariable(VarSpec varSpec, Result result, bool multiVariableExpression = false)
-            {
-                var varname = varSpec.VarName.ToString();
-                result.ParameterNames.Add(varname);
-
-                if (!_Parameters.ContainsKey(varname)
-                    || _Parameters[varname] == null
-                    || (_Parameters[varname] is IList && ((IList) _Parameters[varname]).Count == 0)
-                    || (_Parameters[varname] is IDictionary && ((IDictionary) _Parameters[varname]).Count == 0))
-                {
-                    if (_resolvePartially == true)
-                    {
-                        if (multiVariableExpression)
+                    case States.CopyingLiterals:
+                        if (character == '{')
                         {
-                            if (varSpec.First)
-                            {
-                                result.Append("{");
-                            }
-
-                            result.Append(varSpec.ToString());
+                            currentState = States.ParsingExpression;
+                            currentExpression = new StringBuilder();
+                        }
+                        else if (character == '}')
+                        {
+                            throw new ArgumentException("Malformed template, unexpected } : " + result.ToString());
                         }
                         else
                         {
-                            result.Append("{");
-                            result.Append(varSpec.ToString());
-                            result.Append("}");
+                            result.Append(character);
                         }
-                        return false;
-                    }
-                    return false;
-                }
-
-                if (varSpec.First)
-                {
-                    result.Append(varSpec.OperatorInfo.First);
-                }
-                else
-                {
-                    result.Append(varSpec.OperatorInfo.Seperator);
-                }
-
-                object value = _Parameters[varname];
-
-                // Handle Strings
-                if (value is string)
-                {
-                    var stringValue = (string)value;
-                    if (varSpec.OperatorInfo.Named)
-                    {
-                        result.AppendName(varname, varSpec.OperatorInfo, string.IsNullOrEmpty(stringValue));
-                    }
-                    result.AppendValue(stringValue, varSpec.PrefixLength, varSpec.OperatorInfo.AllowReserved);
-                }
-                else
-                {
-                    // Handle Lists
-                    var list = value as IList;
-                    if (list == null && value is IEnumerable<string>)
-                    {
-                        list = ((IEnumerable<string>)value).ToList<string>();
-                    } ;
-                    if (list != null)
-                    {
-                        if (varSpec.OperatorInfo.Named && !varSpec.Explode)  // exploding will prefix with list name
+                        break;
+                    case States.ParsingExpression:
+                        if (character == '}')
                         {
-                            result.AppendName(varname, varSpec.OperatorInfo, list.Count == 0);
+                            ProcessExpression(currentExpression, result);
+
+                            currentState = States.CopyingLiterals;
+                        }
+                        else
+                        {
+                            currentExpression.Append(character);
                         }
 
-                        result.AppendList(varSpec.OperatorInfo, varSpec.Explode, varname, list);
+                        break;
+                }
+            }
+            if (currentState == States.ParsingExpression)
+            {
+                result.Append("{");
+                result.Append(currentExpression.ToString());
+
+                throw new ArgumentException("Malformed template, missing } : " + result.ToString());
+            }
+
+            if (result.ErrorDetected)
+            {
+                throw new ArgumentException("Malformed template : " + result.ToString());
+            }
+            return result;
+        }
+
+        private void ProcessExpression(StringBuilder currentExpression, Result result)
+        {
+
+            if (currentExpression.Length == 0)
+            {
+                result.ErrorDetected = true;
+                result.Append("{}");
+                return;
+            }
+
+            OperatorInfo op = GetOperator(currentExpression[0]);
+
+            var firstChar = op.Default ? 0 : 1;
+            bool multivariableExpression = false;
+
+            var varSpec = new VarSpec(op);
+            for (int i = firstChar; i < currentExpression.Length; i++)
+            {
+                char currentChar = currentExpression[i];
+                switch (currentChar)
+                {
+                    case '*':
+                        varSpec.Explode = true;
+                        break;
+
+                    case ':':  // Parse Prefix Modifier
+                        var prefixText = new StringBuilder();
+                        currentChar = currentExpression[++i];
+                        while (currentChar >= '0' && currentChar <= '9' && i < currentExpression.Length)
+                        {
+                            prefixText.Append(currentChar);
+                            i++;
+                            if (i < currentExpression.Length) currentChar = currentExpression[i];
+                        }
+                        varSpec.PrefixLength = int.Parse(prefixText.ToString());
+                        i--;
+                        break;
+
+                    case ',':
+                        multivariableExpression = true;
+                        var success = ProcessVariable(varSpec, result, multivariableExpression);
+                        bool isFirst = varSpec.First;
+                        // Reset for new variable
+                        varSpec = new VarSpec(op);
+                        if (success || !isFirst || _resolvePartially) varSpec.First = false;
+                        if (!success && _resolvePartially) {result.Append(",") ; }
+                        break; 
+                        
+
+                    default:
+                        if (IsVarNameChar(currentChar))
+                        {
+                            varSpec.VarName.Append(currentChar);
+                        }
+                        else
+                        {
+                            result.ErrorDetected = true;
+                        }
+                        break;
+                }
+            }
+
+            ProcessVariable(varSpec, result, multivariableExpression);
+            if (multivariableExpression && _resolvePartially) result.Append("}");
+        }
+
+        private bool ProcessVariable(VarSpec varSpec, Result result, bool multiVariableExpression = false)
+        {
+            var varname = varSpec.VarName.ToString();
+            result.ParameterNames.Add(varname);
+
+            if (!_Parameters.ContainsKey(varname)
+                || _Parameters[varname] == null
+                || (_Parameters[varname] is IList && ((IList) _Parameters[varname]).Count == 0)
+                || (_Parameters[varname] is IDictionary && ((IDictionary) _Parameters[varname]).Count == 0))
+            {
+                if (_resolvePartially == true)
+                {
+                    if (multiVariableExpression)
+                    {
+                        if (varSpec.First)
+                        {
+                            result.Append("{");
+                        }
+
+                        result.Append(varSpec.ToString());
                     }
                     else
                     {
+                        result.Append("{");
+                        result.Append(varSpec.ToString());
+                        result.Append("}");
+                    }
+                    return false;
+                }
+                return false;
+            }
 
-                        // Handle associative arrays
-                        var dictionary = value as IDictionary<string, string>;
-                        if (dictionary != null)
+            if (varSpec.First)
+            {
+                result.Append(varSpec.OperatorInfo.First);
+            }
+            else
+            {
+                result.Append(varSpec.OperatorInfo.Seperator);
+            }
+
+            object value = _Parameters[varname];
+
+            // Handle Strings
+            if (value is string)
+            {
+                var stringValue = (string)value;
+                if (varSpec.OperatorInfo.Named)
+                {
+                    result.AppendName(varname, varSpec.OperatorInfo, string.IsNullOrEmpty(stringValue));
+                }
+                result.AppendValue(stringValue, varSpec.PrefixLength, varSpec.OperatorInfo.AllowReserved);
+            }
+            else
+            {
+                // Handle Lists
+                var list = value as IList;
+                if (list == null && value is IEnumerable<string>)
+                {
+                    list = ((IEnumerable<string>)value).ToList<string>();
+                } ;
+                if (list != null)
+                {
+                    if (varSpec.OperatorInfo.Named && !varSpec.Explode)  // exploding will prefix with list name
+                    {
+                        result.AppendName(varname, varSpec.OperatorInfo, list.Count == 0);
+                    }
+
+                    result.AppendList(varSpec.OperatorInfo, varSpec.Explode, varname, list);
+                }
+                else
+                {
+
+                    // Handle associative arrays
+                    var dictionary = value as IDictionary<string, string>;
+                    if (dictionary != null)
+                    {
+                        if (varSpec.OperatorInfo.Named && !varSpec.Explode)  // exploding will prefix with list name
                         {
-                            if (varSpec.OperatorInfo.Named && !varSpec.Explode)  // exploding will prefix with list name
-                            {
-                                result.AppendName(varname, varSpec.OperatorInfo, dictionary.Count() == 0);
-                            }
-                            result.AppendDictionary(varSpec.OperatorInfo, varSpec.Explode, dictionary);
+                            result.AppendName(varname, varSpec.OperatorInfo, dictionary.Count() == 0);
                         }
-                        else
+                        result.AppendDictionary(varSpec.OperatorInfo, varSpec.Explode, dictionary);
+                    }
+                    else
+                    {
+                        // If above all fails, convert the object to string using the default object.ToString() implementation
+                        var stringValue = value.ToString();
+                        if (varSpec.OperatorInfo.Named)
                         {
-                            // If above all fails, convert the object to string using the default object.ToString() implementation
-                            var stringValue = value.ToString();
-                            if (varSpec.OperatorInfo.Named)
-                            {
-                                result.AppendName(varname, varSpec.OperatorInfo, string.IsNullOrEmpty(stringValue));
-                            }
-                            result.AppendValue(stringValue, varSpec.PrefixLength, varSpec.OperatorInfo.AllowReserved);
+                            result.AppendName(varname, varSpec.OperatorInfo, string.IsNullOrEmpty(stringValue));
                         }
-
+                        result.AppendValue(stringValue, varSpec.PrefixLength, varSpec.OperatorInfo.AllowReserved);
                     }
 
                 }
-                return true;
+
             }
-
-            private static bool IsVarNameChar(char c)
-            {
-                return ((c >= 'A' && c <= 'z') //Alpha
-                        || (c >= '0' && c <= '9') // Digit
-                        || c == '_'
-                        || c == '%'
-                        || c == '.');
-            }
-
-            private static OperatorInfo GetOperator(char operatorIndicator)
-            {
-                OperatorInfo op;
-                switch (operatorIndicator)
-                {
-
-                    case '+':
-                    case ';':
-                    case '/':
-                    case '#':
-                    case '&':
-                    case '?':
-                    case '.':
-                        op = _Operators[operatorIndicator];
-                        break;
-
-                    default:
-                        op = _Operators['\0'];
-                        break;
-                }
-                return op;
-            }
-
-            private const string varname = "[a-zA-Z0-9_]*";
-            private const string op = "(?<op>[+#./;?&]?)";
-            private const string var = "(?<var>(?:(?<lvar>" + varname + ")[*]?,?)*)";
-            private const string varspec = "(?<varspec>{" + op + var + "})";
-
-            // (?<varspec>{(?<op>[+#./;?&]?)(?<var>[a-zA-Z0-9_]*[*]?|(?:(?<lvar>[a-zA-Z0-9_]*[*]?),?)*)})
-
-            private Regex _ParameterRegex = null;
-
-            public IDictionary<string,object> GetParameters(Uri uri)
-            {
-                if (_ParameterRegex == null)
-                {
-                    var matchingRegex = CreateMatchingRegex(_template);
-                    lock (this)
-                    {
-                        _ParameterRegex = new Regex(matchingRegex);
-                    }
-                }
-
-                var match = _ParameterRegex.Match(uri.OriginalString);
-                var parameters = new Dictionary<string, object>();
-
-                for(int x = 1; x < match.Groups.Count; x ++)
-                {
-                    if (match.Groups[x].Success)
-                    {
-                        var paramName = _ParameterRegex.GroupNameFromNumber(x);
-                        if (!string.IsNullOrEmpty(paramName))
-                        {
-                            parameters.Add(paramName, Uri.UnescapeDataString(match.Groups[x].Value));
-                        }
-
-                    }
-                }
-                return match.Success ? parameters : null;
-            }
-
-            public static string CreateMatchingRegex(string uriTemplate)
-            {
-                var findParam = new Regex(varspec);
-
-                var template = new Regex(@"([^{]|^)\?").Replace(uriTemplate, @"$+\?"); ;//.Replace("?",@"\?");
-                var regex = findParam.Replace(template, delegate (Match m)
-                {
-                    var paramNames = m.Groups["lvar"].Captures.Cast<Capture>().Where(c => !string.IsNullOrEmpty(c.Value)).Select(c => c.Value).ToList();
-                    var op = m.Groups["op"].Value;
-                    switch (op)
-                    {
-                        case "?":
-                            return GetQueryExpression(paramNames, prefix: "?");
-                        case "&":
-                            return GetQueryExpression(paramNames, prefix: "&");
-                        case "#":
-                            return GetExpression(paramNames, prefix: "#" );
-                        case "/":
-                            return GetExpression(paramNames, prefix: "/");
-
-                        case "+":
-                            return GetExpression(paramNames);
-                        default:
-                            return GetExpression(paramNames);
-                    }
-                    
-                });
-
-                return regex +"$";
-            }
-
-            private static string GetQueryExpression(List<String> paramNames, string prefix)
-            {
-                StringBuilder sb = new StringBuilder();
-                foreach (var paramname in paramNames)
-                {
-
-                    sb.Append(@"\"+prefix+"?");
-                    if (prefix == "?") prefix = "&";
-
-                    sb.Append("(?:");
-                    sb.Append(paramname);
-                    sb.Append("=");
-  
-                    sb.Append("(?<");
-                    sb.Append(paramname);
-                    sb.Append(">");
-                    sb.Append("[^/?&]+");
-                    sb.Append(")");
-                    sb.Append(")?");
-                }
-
-                return sb.ToString();
-            }
-
-
-            private static string GetExpression(List<String> paramNames, string prefix = null)
-            {
-                StringBuilder sb = new StringBuilder();
-
-                foreach (var paramname in paramNames)
-                {
-                    if (string.IsNullOrEmpty(paramname)) continue;
-
-                    if (prefix != null)
-                    {
-                        sb.Append(@"\" + prefix + "?");
-                        prefix = ",";
-                    }
-                    sb.Append("(?<");
-                    sb.Append(paramname);
-                    sb.Append(">");
-                    sb.Append("[^/?&,]+"); // Param Value
-                    sb.Append(")?");
-                }
-
-                return sb.ToString();
-            }
-
-          
+            return true;
         }
 
+        private static bool IsVarNameChar(char c)
+        {
+            return ((c >= 'A' && c <= 'z') //Alpha
+                    || (c >= '0' && c <= '9') // Digit
+                    || c == '_'
+                    || c == '%'
+                    || c == '.');
+        }
+
+        private static OperatorInfo GetOperator(char operatorIndicator)
+        {
+            OperatorInfo op;
+            switch (operatorIndicator)
+            {
+
+                case '+':
+                case ';':
+                case '/':
+                case '#':
+                case '&':
+                case '?':
+                case '.':
+                    op = _Operators[operatorIndicator];
+                    break;
+
+                default:
+                    op = _Operators['\0'];
+                    break;
+            }
+            return op;
+        }
+
+        private const string varname = "[a-zA-Z0-9_]*";
+        private const string op = "(?<op>[+#./;?&]?)";
+        private const string var = "(?<var>(?:(?<lvar>" + varname + ")[*]?,?)*)";
+        private const string varspec = "(?<varspec>{" + op + var + "})";
+
+        // (?<varspec>{(?<op>[+#./;?&]?)(?<var>[a-zA-Z0-9_]*[*]?|(?:(?<lvar>[a-zA-Z0-9_]*[*]?),?)*)})
+
+        private Regex _ParameterRegex = null;
+
+        /// <summary>
+        /// Gets the values of URI template parameters and returns them as a dictionary.
+        /// Be aware that the order of parameters is significant here, i. e. given a template "http://test.tld{? foo, bar}",
+        /// then "http://test.tld?foo=1&bar=2" will get 2 matching parameters, while "http://test.tld?bar=2&foo=1" will get none.
+        /// Use <see cref="GetParametersNonStrict(Uri)"/> if you want a less strict behaviour.
+        /// </summary>
+        /// <param name="uri">The uri to extract the parameters from.</param>
+        /// <returns>A dictionary containing URI template parameters and their values. Will return null when no parameter is found.</returns>
+        public IDictionary<string,object> GetParameters(Uri uri)
+        {
+            if (_ParameterRegex == null)
+            {
+                var matchingRegex = CreateMatchingRegex(_template);
+                lock (this)
+                {
+                    _ParameterRegex = new Regex(matchingRegex);
+                }
+            }
+
+            var match = _ParameterRegex.Match(uri.OriginalString);
+            var parameters = new Dictionary<string, object>();
+
+            for (int x = 1; x < match.Groups.Count; x++)
+            {
+                if (match.Groups[x].Success)
+                {
+                    var paramName = _ParameterRegex.GroupNameFromNumber(x);
+                    if (!string.IsNullOrEmpty(paramName))
+                    {
+                        parameters.Add(paramName, Uri.UnescapeDataString(match.Groups[x].Value));
+                    }
+
+                }
+            }
+            return match.Success ? parameters : null;
+
+        }
+
+        /// <summary>
+        /// Gets the values of URI template parameters and returns them as a dictionary.
+        /// The difference to <see cref="GetParameters(Uri)"/> is that the order of query string params is not significant here.
+        /// </summary>
+        /// <param name="uri">The uri to extract the parameters from.</param>
+        /// <returns>A dictionary containing URI template parameters and their values.</returns>
+        public IDictionary<string, object> GetParametersNonStrict(Uri uri)
+        {
+            // Note that the search for parameters independent of order can also be done using regex, but will not perform well.
+
+            var uriWithoutQuery = new Uri(uri.ToString().Replace(uri.Query, ""), UriKind.RelativeOrAbsolute);
+
+            var parameters = GetParameters(uriWithoutQuery) ?? new Dictionary<string, object>();
+
+            var parameterNames = GetParameterNames();
+            foreach(var queryStringParameter in uri.GetQueryStringParameters())
+            {
+                if (parameterNames.Contains(queryStringParameter.Key))
+                {
+                    parameters.Add(queryStringParameter.Key, queryStringParameter.Value);
+                }
+            }
+
+            return parameters;
+        }
+
+        public static string CreateMatchingRegex(string uriTemplate)
+        {
+            var findParam = new Regex(varspec);
+
+            var template = new Regex(@"([^{]|^)\?").Replace(uriTemplate, @"$+\?"); ;//.Replace("?",@"\?");
+            var regex = findParam.Replace(template, delegate (Match m)
+            {
+                var paramNames = m.Groups["lvar"].Captures.Cast<Capture>().Where(c => !string.IsNullOrEmpty(c.Value)).Select(c => c.Value).ToList();
+                var op = m.Groups["op"].Value;
+                switch (op)
+                {
+                    case "?":
+                        return GetQueryExpression(paramNames, prefix: "?");
+                    case "&":
+                        return GetQueryExpression(paramNames, prefix: "&");
+                    case "#":
+                        return GetExpression(paramNames, prefix: "#" );
+                    case "/":
+                        return GetExpression(paramNames, prefix: "/");
+
+                    case "+":
+                        return GetExpression(paramNames);
+                    default:
+                        return GetExpression(paramNames);
+                }
+                    
+            });
+
+            return regex +"$";
+        }
+
+        private static string GetQueryExpression(List<String> paramNames, string prefix)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var paramname in paramNames)
+            {
+
+                sb.Append(@"\"+prefix+"?");
+                if (prefix == "?") prefix = "&";
+
+                sb.Append("(?:");
+                sb.Append(paramname);
+                sb.Append("=");
+  
+                sb.Append("(?<");
+                sb.Append(paramname);
+                sb.Append(">");
+                sb.Append("[^/?&]+");
+                sb.Append(")");
+                sb.Append(")?");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetExpression(List<String> paramNames, string prefix = null)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var paramname in paramNames)
+            {
+                if (string.IsNullOrEmpty(paramname)) continue;
+
+                if (prefix != null)
+                {
+                    sb.Append(@"\" + prefix + "?");
+                    prefix = ",";
+                }
+                sb.Append("(?<");
+                sb.Append(paramname);
+                sb.Append(">");
+                sb.Append("[^/?&,]+"); // Param Value
+                sb.Append(")?");
+            }
+
+            return sb.ToString();
+        }
         
-    }
+    }    
+}


### PR DESCRIPTION
Hi Darell!

Finally I made the change we discussed recently. Notes:
- added a new method "GetParametersNonStrict()". "GetParameters()" still works as before.
- "GetParametersNonStrict()" does NOT return null when there's no match, but an empty dictionary
- "GetParameters()" still returns null when there is no match. I would change this behaviour.
    - if you want me to change this, please let me know, I'm into the code now and can do it in a minute
- added some unit tests

Regards,
Khalid