### PR TITLE
Advertises Conversion from String

### DIFF
--- a/src/UriTemplates/UriTemplateConverter.cs
+++ b/src/UriTemplates/UriTemplateConverter.cs
@@ -11,6 +11,12 @@ namespace Tavis.UriTemplates
         : TypeConverter
     {
         /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        /// <inheritdoc/>
         public override object ConvertFrom(
             ITypeDescriptorContext context,
             CultureInfo culture,


### PR DESCRIPTION
I was so reliant on the `ConvertFromInvariantString` method in my workarounds that I forgot to advertise `string` conversion capabilities in the `TypeConverter`.

Apologies.
