### PR TITLE
Fix: Ensures strict regex matching by adding negative lookbehind

### DIFF
--- a/src/UriTemplateTests/UriTemplateTableTests.cs
+++ b/src/UriTemplateTests/UriTemplateTableTests.cs
@@ -21,7 +21,9 @@ namespace UriTemplateTests
         InlineData("/baz/kit", "kit"),
         InlineData("/baz/fod", "baz"),
         InlineData("/baz/fod/blob", "blob"),
-        InlineData("/glah/flid/blob", "goo")]
+        InlineData("/glah/flid/blob", "goo"),
+        InlineData("/settings/{id}", "set"),
+        InlineData("/organization/{id}/settings/iteminsights", "org")]
         public void FindPathTemplates(string url, string key)
         {
             var table = new UriTemplateTable();  // Shorter paths and literal path segments should be added to the table first.
@@ -31,6 +33,8 @@ namespace UriTemplateTests
             table.Add("baz", new UriTemplate("/baz/{bar}"));
             table.Add("blob", new UriTemplate("/baz/{bar}/blob"));
             table.Add("goo", new UriTemplate("/{goo}/{bar}/blob"));
+            table.Add("set", new UriTemplate("/settings/{id}"));
+            table.Add("org", new UriTemplate("/organization/{id}/settings/iteminsights"));
 
 
             var result = table.Match(new Uri(url, UriKind.RelativeOrAbsolute));

--- a/src/UriTemplates/UriTemplate.cs
+++ b/src/UriTemplates/UriTemplate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -409,7 +409,7 @@ namespace Tavis.UriTemplates
                     
                 });
 
-                return regex +"$";
+                return "(?<!.)\\" + regex +"$"; // add negative lookbehind to strictly match this regex
             }
 
         public static string CreateMatchingRegex2(string uriTemplate)

--- a/src/UriTemplates/UriTemplate.cs
+++ b/src/UriTemplates/UriTemplate.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Tavis.UriTemplates
@@ -36,7 +32,7 @@ namespace Tavis.UriTemplates
             private readonly string _template;
             private readonly Dictionary<string, object> _Parameters;
             private enum States { CopyingLiterals, ParsingExpression }
-            
+
 
             private readonly bool _resolvePartially;
 
@@ -191,8 +187,8 @@ namespace Tavis.UriTemplates
                             varSpec = new VarSpec(op);
                             if (success || !isFirst || _resolvePartially) varSpec.First = false;
                             if (!success && _resolvePartially) {result.Append(",") ; }
-                            break; 
-                        
+                            break;
+
 
                         default:
                             if (IsVarNameChar(currentChar))
@@ -406,7 +402,7 @@ namespace Tavis.UriTemplates
                         default:
                             return GetExpression(paramNames);
                     }
-                    
+
                 });
 
                 return "(?<!.)\\" + regex +"$"; // add negative lookbehind to strictly match this regex
@@ -456,7 +452,7 @@ namespace Tavis.UriTemplates
                     sb.Append("(?:");
                     sb.Append(paramname);
                     sb.Append("=");
-  
+
                     sb.Append("(?<");
                     sb.Append(paramname);
                     sb.Append(">");
@@ -519,8 +515,8 @@ namespace Tavis.UriTemplates
                 return sb.ToString();
             }
 
-          
+
         }
 
-        
+
     }


### PR DESCRIPTION
Proposes:
- Adding negative lookbehind to the regex to ensure strict matching of urls.
- Adding test data to validate this fix.