### PR TITLE
Remove .NET FX and only support Netstandard2

### DIFF
--- a/src/UriTemplates/UriTemplates.csproj
+++ b/src/UriTemplates/UriTemplates.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Tavis.UriTemplates</AssemblyName>
     <Description>URI Template resolution library - Implementation of RFC 6570</Description>
     <Authors>Darrel Miller</Authors>
-    <Version>3.0.0</Version>
+    <Version>2.0.0</Version>
     <PackageReleaseNotes><![CDATA[
             For full release notes see https://github.com/tavis-software/Tavis.UriTemplates/blob/master/ReleaseNotes.md
             ]]></PackageReleaseNotes>

--- a/src/UriTemplates/UriTemplates.csproj
+++ b/src/UriTemplates/UriTemplates.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RootNamespace>Tavis</RootNamespace>
     <AssemblyName>Tavis.UriTemplates</AssemblyName>
     <Description>URI Template resolution library - Implementation of RFC 6570</Description>
     <Authors>Darrel Miller</Authors>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <PackageReleaseNotes><![CDATA[
             For full release notes see https://github.com/tavis-software/Tavis.UriTemplates/blob/master/ReleaseNotes.md
             ]]></PackageReleaseNotes>


### PR DESCRIPTION
Major version was bumped on previous commit.

Should fix #73 