### PR TITLE
Fix error in GetQueryStringParameters when key appears more than once

### DIFF
--- a/src/UriTemplateTests/UriExtensionTests.cs
+++ b/src/UriTemplateTests/UriExtensionTests.cs
@@ -84,5 +84,23 @@ namespace UriTemplateTests
 
             Assert.Equal("http://example/customer/99?view=true&context=detail", template.Resolve());
         }
+
+        [Fact]
+        public void Duplicate_query_string_key_should_parse()
+        {
+            var target = new Uri("http://example/customer?color=blue&color=red");
+            var template = target.MakeTemplate();
+
+            Assert.Equal("http://example/customer?color=blue,red", template.Resolve());
+        }
+
+        [Fact]
+        public void Query_string_parameter_with_multiple_values_should_parse()
+        {
+            var target = new Uri("http://example/customer?color=blue,red");
+            var template = target.MakeTemplate();
+
+            Assert.Equal("http://example/customer?color=blue,red", template.Resolve());
+        }
     }
 }

--- a/src/UriTemplates/UriTemplateExtensions.cs
+++ b/src/UriTemplates/UriTemplateExtensions.cs
@@ -72,18 +72,22 @@ namespace Tavis.UriTemplates
         public static Dictionary<string, object> GetQueryStringParameters(this Uri target)
         {
             Uri uri = target;
-            var parameters = new Dictionary<string, object>();
+            var parameters = new List<KeyValuePair<string, object>>();
 
             var reg = new Regex(@"([-A-Za-z0-9._~]*)=([^&]*)&?");		// Unreserved characters: http://tools.ietf.org/html/rfc3986#section-2.3
             foreach (Match m in reg.Matches(uri.Query))
             {
                 string key = m.Groups[1].Value.ToLowerInvariant();
-                string value = m.Groups[2].Value;
-                parameters.Add(key, value);
+                string values = m.Groups[2].Value;
+
+                // Avoid encoding ',' in query string parameters
+                foreach(var value in values.Split(','))
+                {
+                    parameters.Add(new KeyValuePair<string, object>(key, value));
+                }
             }
-            return parameters;
+
+            return parameters.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => (object) x.Select(a => a.Value).ToArray());
         }
-
-
     }
 }


### PR DESCRIPTION
This PR fixes the current implementation of `GetQueryStringParameters` that throws an exception when the URI's query string contains multiple time the same key.

Also this PR correctly handles the comma separated values during parsing to avoid encoding the ','